### PR TITLE
Turn on flag.Usage() again on bad params exit.

### DIFF
--- a/outcomes_import_tool.go
+++ b/outcomes_import_tool.go
@@ -152,7 +152,7 @@ func normalizeDomain(domain string) string {
 }
 
 func errAndExit(message ...interface{}) {
-	// flag.Usage()
+	flag.Usage()
 	log.Fatalln(message...)
 	os.Exit(1)
 }


### PR DESCRIPTION
On Go 1.5 flag.Usage() returns good looking output.  Having this will be a bit easier for the tool novices.
